### PR TITLE
Fail usefully when docs.json is malformed

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,8 +33,8 @@ try {
   configPath = path.join(process.cwd(), configPath);
   config = require(configPath);
 } catch(e) {
-  console.error('Could not load config at: "%s"', configPath);
-  process.exit();
+  console.error('Could not load config: %s', e.message);
+  process.exit(1);
 }
 
 /*


### PR DESCRIPTION
Usefully means printing what's wrong with the json, not just the name of
the file, and not exiting with success after failing.
