### PR TITLE
Log only the URL in non-TTY mode.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -70,9 +70,13 @@ if(previewMode) {
   });
   
   app.listen(port, function () {
-    console.log('Preview your docs @ http://localhost:' + port);
-    console.log();
-    console.log('Refresh your browser to rebuild.');
+    if (process.stdout.isTTY) {
+      console.log('Preview your docs @ http://localhost:' + port);
+      console.log();
+      console.log('Refresh your browser to rebuild.');
+    } else {
+      console.log('http://localhost:' + port);
+    }
   });
 }
 


### PR DESCRIPTION
This might be a candidate for a small module: If you run `sdocs -p` in non-TTY mode, only the URL of the now-running app is sent to stdout. This is really handy as the following:

```
sdocs -p | xargs -n 1 open
```
