### PR TITLE
Better handling of markdown in headers and annotations

### DIFF
--- a/lib/annotation.js
+++ b/lib/annotation.js
@@ -42,6 +42,11 @@ function Annotation(comment, doc) {
 
       fn.call(this, tag);
     }
+
+    if(tag.description) {
+      tag.description = marked(tag.description, doc.markedOptions);
+    }
+
   }.bind(this));
 
   if(attrs.ignore || attrs.private || comment.ignore) {
@@ -340,12 +345,12 @@ var tagParsers = {
   version: notSupported
 }
 
-function notSupported (tag) {
+function notSupported(tag) {
   debug('attribute "@%s" not supported', tag.type);
   debug("tag: %j", tag);
 }
 
-function setProperty (tag) {
+function setProperty(tag) {
   this.attrs[tag.type] = tag.string || true;
 }
 
@@ -361,7 +366,7 @@ function stringToSectionTitle(str) {
 }
 
 // monkey patch dox comment
-function patch (comment) {
+function patch(comment) {
   comment = comment || {};
   var desc = comment.description && comment.description.full;
 
@@ -372,7 +377,7 @@ function patch (comment) {
   return comment;
 }
 
-function stringToClassHeader (str) {
+function stringToClassHeader(str) {
   var result = camel(removeArgs(str), true);
   result += ' = new ';
   result += str;

--- a/lib/doc.js
+++ b/lib/doc.js
@@ -16,6 +16,7 @@ var debug = require('debug')('Doc')
   , path = require('path')
   , hljs = require('highlight.js')
   , assert = require('assert')
+  , string = require('underscore.string')
   , Annotation = require('./annotation');
   
 var languageAlias = {
@@ -173,10 +174,19 @@ function branchToTitle(branch) {
 }
 
 function stringToTitle(str) {
+  var html = marked.parse(str);
+
+  // html back to string
+  str = html.replace(/<.+?>/g, '');
+
   // remove function arguments
-  str = str.replace(/\(.+\)/, '');
+  str = str.replace(/\(.+\)/g, '');
   str = str.replace('()', '');
-  return str;
+
+  // remove anything in angle bracks
+  str = str.replace(/\[.+?\]/g, '');
+
+  return string.trim(str);
 }
 
 function headerToString(branch) {

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -4,7 +4,7 @@
 
 module.exports = Docs;
 
-/**
+/*!
  * Module dependencies.
  */
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -59,14 +59,14 @@ a[name] {
   margin-top: 10px;
   margin-left: 20px;
 }
-.code-arg div {
-  display: inline;
-}
 .code-arg-types {
   font-weight: bold;
 }
 .code-arg-types:before { content: "{"; }
 .code-arg-types:after { content: "}"; }
+.code-arg-desc {
+  margin-top: 10px;
+}
 
 .intentionally-left-blank {
   display: block;

--- a/templates/annotation.ejs
+++ b/templates/annotation.ejs
@@ -59,7 +59,7 @@
       </span>
     </div>
     <div class="code-arg-desc">
-      <%= arg.description || '' %>
+      <%- arg.description || '' %>
     </div>
   </div>
 <% } %>

--- a/test/docs.test.js
+++ b/test/docs.test.js
@@ -89,5 +89,23 @@ describe('Docs', function() {
         done();
       });
     });
-  })
+  });
+
+  describe('complex headers', function () {
+    it('should not include markdown', function (done) {
+      Docs.parse({
+        content: ['fixtures/complex-headers.md'],
+        root: __dirname
+      }, function (err, docs) {
+        var sections = docs.content[0].sections;
+        assert.equal(sections[0].title, 'complex-headers');
+        assert.equal(sections[1].title, 'link');
+        assert.equal(sections[2].title, 'bold header');
+        assert.equal(sections[3].title, 'code.header');
+        assert.equal(sections[4].title, 'slc create');
+        assert.equal(sections[5].title, 'workspace');
+        done();
+      });
+    });
+  });
 });

--- a/test/fixtures/complex-attrs.js
+++ b/test/fixtures/complex-attrs.js
@@ -4,8 +4,7 @@
  *     @property {Integer} size The size, note whitespace is not syntactic
  *     @property {String} string a string  // could use @param here, it kindof is, but it is also a property of options param // note whitespace isn't significant, so wrapping is ok
  * @end // end of options
- * @callback callback called when
- * the function did something
+ * @callback callback called when the function did something
  * @param {Error} err whether it worked
  * @end //optional, since there is nothing after
 */

--- a/test/fixtures/complex-headers.md
+++ b/test/fixtures/complex-headers.md
@@ -1,0 +1,7 @@
+# complex-headers
+
+## [link](#header)
+## **bold** header
+## code.header(with, [args])
+## slc create <type> <name>
+## workspace <name> [args]


### PR DESCRIPTION
/to @Schoonology 

Before, some markdown (such as links) were showing up as text in headers.

```
## [My Link](#something)
```

would show up as

```
[My Link]
```

Also added support for markdown in attributes.

```
@param {String} str This now **supports** markdown...
```
