### PR TITLE
Use `@class` value as the name (header)

### DIFF
--- a/lib/annotation.js
+++ b/lib/annotation.js
@@ -90,6 +90,8 @@ function Annotation(comment, doc) {
   // build header
   if (attrs.name || attrs.alias) {
     header = attrs.name || attrs.alias;
+  } else if (typeof attrs.class === 'string') {
+    header = attrs.class;
   } else if(type === 'overview') {
     header = doc.filename;
     if(!desc) {


### PR DESCRIPTION
I figured out it's better to specify the class name as `@class User` instead of `@class @name User`, as the former is recognized by WebStorm, but the latter is not.

@ritch please review and merge if LGTY.
