### PR TITLE
Support ngdoc comments

### DIFF
--- a/lib/annotation.js
+++ b/lib/annotation.js
@@ -27,7 +27,6 @@ function Annotation(comment, doc) {
   var doc = this.doc = doc;
   var docs = this.docs = doc.docs;
   var attrs = this.attrs = {};
-  var desc = comment.description && comment.description.full;
 
   tags.forEach(function (tag) {
     if(tag.type) {
@@ -48,6 +47,9 @@ function Annotation(comment, doc) {
     }
 
   }.bind(this));
+
+  var desc = attrs.description /* ngdoc style */ ||
+    comment.description && comment.description.full /* jsdoc/dox style */;
 
   if(attrs.ignore || attrs.private || comment.ignore) {
     this.ignore = true;
@@ -87,10 +89,12 @@ function Annotation(comment, doc) {
     }
   }
 
-  // build header
   if (attrs.name || attrs.alias) {
-    header = attrs.name || attrs.alias;
-  } else if (typeof attrs.class === 'string') {
+    name = attrs.name || attrs.alias;
+  }
+
+  // build header
+  if (typeof attrs.class === 'string') {
     header = attrs.class;
   } else if(type === 'overview') {
     header = doc.filename;
@@ -112,8 +116,8 @@ function Annotation(comment, doc) {
         return t.name
       })
       .join(', ');
-      
-    header = name.replace('()', '('+ argNames +')');
+
+    header = name.replace(/\(\)\s*$/, '') + '('+ argNames +')';
   } else if(name) {
     header = name;
   }
@@ -259,7 +263,8 @@ Annotation.prototype.render = function () {
 var aliases = {
   function: 'method',
   file: 'overview',
-  prop: 'property'
+  prop: 'property',
+  desc: 'description'
 };
 
 var tagParsers = {
@@ -283,7 +288,7 @@ var tagParsers = {
   copyright: notSupported,
   default: notSupported,
   deprecated: setProperty,
-  desc: setProperty,
+  description: setProperty,
   enum: notSupported,
   event: notSupported,
   example: setProperty,


### PR DESCRIPTION
- Rework `@desc` as an alias for `@description`
- Use `@description` as the entity description if it is available.
- Append arguments to functions that have `@name` tag
- Append arguments string also to functions that don't have
  trailing `()` in their name

See also https://github.com/strongloop/loopback-sdk-angular/issues/87

Things not covered by this PR, will be done later:
- Support `{function(param1,param2)}` types. They are rendered as `{function(param1 or param)}` now.
- Support `{@link href name}` in markdown content.

/to @ritch please review
