### PR TITLE
Fix incorrect rendering of class title

### DIFF
--- a/lib/annotation.js
+++ b/lib/annotation.js
@@ -142,7 +142,6 @@ function Annotation(comment, doc) {
     this.methods = [];
     this.propertyAnnotations = [];
     this.sectionTitle = 'Class: ' + header;
-    header = stringToClassHeader(header);
     if(typeof this.attrs.class === 'string') {
       this.classDesc = this.attrs.class;
     }
@@ -170,6 +169,10 @@ function Annotation(comment, doc) {
   } else {
     this.html = '';
     console.log('No description found for %s', name);
+  }
+
+  if(type === 'class') {
+    header = stringToClassHeader(header);
   }
 
   this.header = header;
@@ -498,8 +501,8 @@ function patch(comment) {
 }
 
 function stringToClassHeader(str) {
-  var result = camel(removeArgs(str), true);
-  result += ' = new ';
+  if (str.indexOf('var') === 0) return str;
+  var result = 'Class: ';
   result += str;
   return result;
 }


### PR DESCRIPTION
Remove unnecessary code component from the class title text.

Tip: To manually set the class title text, use the `@header` annotation.
