### PR TITLE
Type script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: node_js
+node_js:
+  - "6"
+  - "8"

--- a/lib/doc.js
+++ b/lib/doc.js
@@ -17,8 +17,7 @@ var debug = require('debug')('Doc')
   , hljs = require('highlight.js')
   , assert = require('assert')
   , string = require('underscore.string')
-  , Annotation = require('./annotation')
-  , TSParser = require('./tsParser');
+  , Annotation = require('./annotation');
 
 var languageAlias = {
   sh: 'bash',
@@ -68,12 +67,11 @@ var markedOptions = {
  * @constructor
  */
 
-function Doc(file, contents, flags, docs) {
+function Doc(file, contents, isJS, docs) {
   var doc = this;
   this.docs = docs;
   this.file = file;
-  var isJS = this.isJS = flags.isJS;
-  var isTS = this.isTS = flags.isTS;
+  var isJS = this.isJS = isJS;
   this.markedOptions = markedOptions;
   this.contents = contents;
   this.filename = path.basename(file);
@@ -86,31 +84,24 @@ function Doc(file, contents, flags, docs) {
 
   this.commentTemplate = docs.commentTemplate;
   try {
-    if (isJS || isTS) {
-      if (isJS) {
-        this.parseJavaScript();
-        this.classes = this.classes.sort(function(a, b) {
-          return a.section.title.localeCompare(b.section.title);
+    if (isJS) {
+      this.parseJavaScript();
+      this.classes = this.classes.sort(function(a, b) {
+        return a.section.title.localeCompare(b.section.title);
+      });
+      this.classes.forEach(function(classAnnotation) {
+        renderClass(classAnnotation);
+        if (('classDesc' in classAnnotation) && docs.renderedClasses.indexOf(classAnnotation.classDesc) < 0) {
+          docs.renderedClasses.push(classAnnotation.classDesc);
+        }
+        classAnnotation.methods.sort(function(a, b) {
+          a = a.section.title.split('.').pop();
+          b = b.section.title.split('.').pop();
+          return a.localeCompare(b);
+        }).forEach(function (annot) {
+          renderMethod(annot, docs.classes[classAnnotation.classDesc])
         });
-        this.classes.forEach(function(classAnnotation) {
-          renderClass(classAnnotation);
-          if (('classDesc' in classAnnotation) && docs.renderedClasses.indexOf(classAnnotation.classDesc) < 0) {
-            docs.renderedClasses.push(classAnnotation.classDesc);
-          }
-          classAnnotation.methods.sort(function(a, b) {
-            a = a.section.title.split('.').pop();
-            b = b.section.title.split('.').pop();
-            return a.localeCompare(b);
-          }).forEach(function (annot) {
-            renderMethod(annot, docs.classes[classAnnotation.classDesc])
-          });
-        });
-      } else if (isTS) {
-        this.parseTypeScript();
-        this.classes.forEach(function(tsConstruct) {
-          renderTSConstruct(tsConstruct);
-        });
-      }
+      });
     } else {
       this.parseMarkdown();
     }
@@ -118,11 +109,6 @@ function Doc(file, contents, flags, docs) {
     console.error('Failed to parse %s', this.filename);
     console.error(e);
     console.log(e.stack);
-  }
-
-  function renderTSConstruct(classConstruct) {
-    if (!('html' in doc)) doc.html = '';
-    doc.html += classConstruct.render();
   }
 
   function renderClass(classAnnotation, classRendered) {
@@ -195,13 +181,6 @@ Doc.prototype.parseJavaScript = function () {
     }
   }
 }
-
-Doc.prototype.parseTypeScript = function() {
-  var tsParser = new TSParser(this.file);
-  var parsedData = tsParser.parse();
-  this.classes = parsedData.constructs;
-  this.sections = parsedData.sections;
-};
 
 /**
  * Parse the `doc.contents` as markdown.

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -17,7 +17,8 @@ var debug = require('debug')('docs')
   , TaskEmitter = require('strong-task-emitter')
   , assert = require('assert')
   , string = require('underscore.string')
-  , COMMENT_TEMPLATE = path.join(__dirname, '..', 'templates', 'annotation.ejs');
+  , COMMENT_TEMPLATE = path.join(__dirname, '..', 'templates', 'annotation.ejs')
+  , TSParser = require('./tsParser');
 
 /*!
  * Create a new set of `Docs` with the given `config`.
@@ -152,12 +153,17 @@ Docs.prototype.parse = function (fn) {
   var te = new TaskEmitter();
   var files = {};
   var matchedFiles = [];
+  var tsFiles = [];
   // reference to individual classes
   this.classes = {};
   te.on('error', fn);
   te.on('done', function () {
     matchedFiles.forEach(function (f) {
-      console.log('processing file: ' + f);
+      if (path.extname(f) === '.ts') {
+        // Filter out ts files, and process them as a bunch
+        tsFiles.push(f);
+        return;
+      }
       var contents;
 
       if(typeof f === 'object') {
@@ -168,7 +174,7 @@ Docs.prototype.parse = function (fn) {
         f = path.resolve(root, f);
         contents = files[f];
         if(this.hasExt(f)) { 
-          var doc = new Doc(f, contents, {isJS: path.extname(f) === '.js', isTS: path.extname(f) === '.ts'}, self);
+          var doc = new Doc(f, contents, path.extname(f) === '.js', self);
           doc.classes.forEach(function (c) {
             if (!(c.classDesc in self.classes)) {
               self.classes[c.classDesc] = doc;
@@ -178,6 +184,20 @@ Docs.prototype.parse = function (fn) {
         }
       }
     }.bind(this));
+    // Process ts files
+    if(tsFiles.length > 0) {
+      var tsParser = new TSParser(tsFiles);
+      var parsedData = tsParser.parse();
+      var doc = {
+        classes: parsedData.constructs,
+        sections: parsedData.sections,
+        html: ''
+      }
+      doc.classes.forEach(function(tsConstruct) {
+        doc.html += tsConstruct.render();
+      });
+      self.content.push(doc);
+    }
     this.buildSections();
     fn();
   }.bind(this));

--- a/lib/tsConstruct.js
+++ b/lib/tsConstruct.js
@@ -41,6 +41,10 @@ TSConstruct.prototype.render = function() {
   }
   this.node.filename =
   this.templates[this.node.kindString.toLowerCase()].filename;
+  // HACK: for some reason "comment" is not getting passed in EJS include
+  // May be it is a keyword and treated differently, should copy it in
+  // to another varaible comment_copy that gets passed on to included template.          
+  this.node.comment_copy = this.node.comment;
   return ejs.render(
     this.templates[this.node.kindString.toLowerCase()].file, this.node
   );

--- a/lib/tsConstruct.js
+++ b/lib/tsConstruct.js
@@ -7,7 +7,8 @@ var ejs = require('ejs'),
   path = require('path'),
   TS_CLASS_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'class.ejs'),
   TS_INTERFACE_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'interface.ejs'),
-  TS_FUNCTION_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'function.ejs');
+  TS_FUNCTION_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'function.ejs'),
+  TS_TYPE_ALIAS_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'typeAlias.ejs');
 
 function TSConstruct(node) {
   this.node = node;
@@ -24,6 +25,10 @@ function TSConstruct(node) {
       filename: TS_FUNCTION_TEMPLATE,
       file: fs.readFileSync(TS_FUNCTION_TEMPLATE, 'utf8'),
     },
+    'typealias': {
+      filename: TS_TYPE_ALIAS_TEMPLATE,
+      file: fs.readFileSync(TS_TYPE_ALIAS_TEMPLATE, 'utf8'),
+    },
   };
 }
 
@@ -31,6 +36,9 @@ function TSConstruct(node) {
  * Render the annotation as html.
  */
 TSConstruct.prototype.render = function() {
+  if(this.node.kindString === 'Type alias'){
+    this.node.kindString = 'typealias';
+  }
   this.node.filename =
   this.templates[this.node.kindString.toLowerCase()].filename;
   return ejs.render(

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -54,8 +54,8 @@ TSParser.prototype.parse = function() {
               (child.kindString === 'Property' && !child.inheritedFrom && !child.flags.isPrivate && !child.flags.isProtected) ||
               (child.kindString === 'Constructor' && !child.inheritedFrom) ||
               (child.kindString === 'Method' && !child.inheritedFrom && !child.flags.isPrivate && !child.flags.isProtected)
-              ) {                
-              // This is needed in UI, good to keep the elibility logic at one place
+              ) {   
+             // This is needed in UI, good to keep the elibility logic at one place
               child.shouldDocument = true;
               processMarkdown(child);
               if (child.kindString !== 'Property') {
@@ -105,7 +105,7 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
 
 function createAnchor(node) {
   //node.anchorId = node.kindString + node.name.replace('$', '') + node.id;
-  if (node.kindString === 'Class' || node.kindString === 'Interface') {
+  if (node.kindString === 'Class' || node.kindString === 'Interface' || node.kindString === 'Type alias') {
     node.anchorId = node.name;
   } else {
     node.anchorId = node.id;

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -87,7 +87,8 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
       (node.kindString === 'Function' &&
         node.flags.isExported)) && 
         filePaths.find(function(filePath){
-          if(node.sources[0].fileName.indexOf(filePath) > -1 || filePath.indexOf(node.sources[0].fileName)){
+          if(node.sources[0].fileName.split("/").pop() === filePath.split("/").pop()){
+            console.log(node.sources[0].fileName+" :: "+filePath)
             return true;
           }
         })    

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -53,7 +53,7 @@ TSParser.prototype.parse = function() {
               (child.kindString === 'Property' && !child.flags.isPrivate && !child.flags.isProtected) ||
               (child.kindString === 'Constructor') ||
               (child.kindString === 'Method' && !child.flags.isPrivate && !child.flags.isProtected)
-              ) {
+              ) {                
               // This is needed in UI, good to keep the elibility logic at one place
               child.shouldDocument = true;
               processMarkdown(child);
@@ -120,6 +120,19 @@ function processMarkdown(node) {
       if(node.comment.text){
         node.comment.text = marked(node.comment.text);
       }
+    }
+    if(node.signatures){
+      console.log(node.name + ' has signatures');
+      node.signatures.forEach(function(signature){
+        if(signature.comment){
+          if(signature.comment.shortText){
+            signature.comment.shortText = marked(signature.comment.shortText);
+          }
+          if(signature.comment.text){
+            signature.comment.text = marked(signature.comment.text);
+          }
+        }
+      });
     }
     var children = node.children || (node.signatures && node.signatures[0].parameters);
     if (children && children.length > 0) {

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -4,7 +4,14 @@ module.exports = TSParser;
 
 var typedoc = require('typedoc'),
   path = require('path'),
-  TSConstruct = require('./tsConstruct');
+  TSConstruct = require('./tsConstruct'),
+  marked = require('marked');
+
+marked.setOptions({
+  highlight: function(code) {
+    return require('highlight.js').highlightAuto(code).value;
+  }
+});
 
 var app = new typedoc.Application({
   mode: 'Modules',
@@ -15,28 +22,27 @@ var app = new typedoc.Application({
   includeDeclarations: true,
 });
 
-function TSParser(file) {
-  this.file = file;
-  this.filename = path.basename(file);
+function TSParser(filePaths) {
+  this.filePaths = filePaths;
   this.sections = [];
   this.constructs = [];
 }
 
 TSParser.prototype.parse = function() {
-  var filePaths = [];
-  filePaths.push(this.file);
-  var project = app.convert(filePaths);
+  var project = app.convert(this.filePaths);
+  
   if (!project) {
     console.log('Could not create project for file: ' + this.filename);
   } else {
-    var exportedConstructs = this.findExportedConstructs(project.toObject(), this.filename);
+    var exportedConstructs = this.findExportedConstructs(project.toObject(), this.filePaths);
     exportedConstructs.forEach(function(node) {
       if (node.kindString === 'Class' ||
           node.kindString === 'Interface' ||
           node.kindString === 'Function') {
-        this.constructs.push(new TSConstruct(node));
-        createAnchor(node);
-        this.sections.push({'title': node.kindString + ': ' + node.name,
+            processMarkdown(node);
+            this.constructs.push(new TSConstruct(node));
+            createAnchor(node);
+            this.sections.push({'title': node.kindString + ': ' + node.name,
           'anchor': node.anchorId, 'depth': 3});
         // build sections for children
         var children = node.children;
@@ -50,6 +56,7 @@ TSParser.prototype.parse = function() {
               ) {
               // This is needed in UI, good to keep the elibility logic at one place
               child.shouldDocument = true;
+              processMarkdown(child);
               if (child.kindString !== 'Property') {
                 // Don't create section for property
                 createAnchor(child);
@@ -64,30 +71,58 @@ TSParser.prototype.parse = function() {
   return {'sections': this.sections, 'constructs': this.constructs};
 };
 
-TSParser.prototype.findExportedConstructs = function(node, filename) {
+TSParser.prototype.findExportedConstructs = function(node, filePaths) {
   var exportedConstructs = [];
-  function findConstructs(node, filename) {
+  function findConstructs(node, filePaths) {
     if (node.kind === 0 || node.kind === 1) {
       var children = node.children;
       if (children && children.length > 0) {
         children.forEach(function(child) {
-          findConstructs(child, filename);
+          findConstructs(child, filePaths);
         });
       }
     } else {
       if ((node.kindString === 'Class' ||
       node.kindString === 'Interface' ||
       (node.kindString === 'Function' &&
-        node.flags.isExported)) && node.sources[0].fileName.indexOf(filename) !== -1) {
-        // console.log(JSON.stringify(node, null, 2));
+        node.flags.isExported)) && 
+        filePaths.find(function(filePath){
+          return filePath.indexOf(node.sources[0].fileName) > -1
+        })    
+        ) {   
         exportedConstructs.push(node);
       }
     }
   };
-  findConstructs(node, filename);
+  findConstructs(node, filePaths);
   return exportedConstructs;
 };
 
 function createAnchor(node) {
-  node.anchorId = node.kindString + node.name.replace('$', '') + node.id;
+  //node.anchorId = node.kindString + node.name.replace('$', '') + node.id;
+  if (node.kindString === 'Class' || node.kindString === 'Interface') {
+    node.anchorId = node.name;
+  } else {
+    node.anchorId = node.id;
+  } 
+};
+
+function processMarkdown(node) {
+  function prsMrkdn(node) {
+    if(node.comment){
+      if(node.comment.shortText){
+        node.comment.shortText = marked(node.comment.shortText);
+      }
+      if(node.comment.text){
+        node.comment.text = marked(node.comment.text);
+      }
+    }
+    var children = node.children || (node.signatures && node.signatures[0].parameters);
+    if (children && children.length > 0) {
+      children.forEach(function(child) {
+        prsMrkdn(child);
+      });
+    }
+  }
+  prsMrkdn(node);
 };

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -38,7 +38,8 @@ TSParser.prototype.parse = function() {
     exportedConstructs.forEach(function(node) {
       if (node.kindString === 'Class' ||
           node.kindString === 'Interface' ||
-          node.kindString === 'Function') {
+          node.kindString === 'Function' ||
+          node.kindString === 'Type alias') {
             processMarkdown(node);
             this.constructs.push(new TSConstruct(node));
             createAnchor(node);
@@ -50,9 +51,9 @@ TSParser.prototype.parse = function() {
              children && children.length > 0) {
           children.forEach(function(child) {
             if (
-              (child.kindString === 'Property' && !child.flags.isPrivate && !child.flags.isProtected) ||
-              (child.kindString === 'Constructor') ||
-              (child.kindString === 'Method' && !child.flags.isPrivate && !child.flags.isProtected)
+              (child.kindString === 'Property' && !child.inheritedFrom && !child.flags.isPrivate && !child.flags.isProtected) ||
+              (child.kindString === 'Constructor' && !child.inheritedFrom) ||
+              (child.kindString === 'Method' && !child.inheritedFrom && !child.flags.isPrivate && !child.flags.isProtected)
               ) {                
               // This is needed in UI, good to keep the elibility logic at one place
               child.shouldDocument = true;
@@ -84,11 +85,11 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
     } else {
       if ((node.kindString === 'Class' ||
       node.kindString === 'Interface' ||
+      node.kindString === 'Type alias' ||
       (node.kindString === 'Function' &&
         node.flags.isExported)) && 
         filePaths.find(function(filePath){
           if(node.sources[0].fileName.split("/").pop() === filePath.split("/").pop()){
-            console.log(node.sources[0].fileName+" :: "+filePath)
             return true;
           }
         })    
@@ -122,7 +123,6 @@ function processMarkdown(node) {
       }
     }
     if(node.signatures){
-      console.log(node.name + ' has signatures');
       node.signatures.forEach(function(signature){
         if(signature.comment){
           if(signature.comment.shortText){

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -73,7 +73,7 @@ TSParser.prototype.parse = function() {
 
 TSParser.prototype.findExportedConstructs = function(node, filePaths) {
   var exportedConstructs = [];
-  function findConstructs(node, filePaths) {
+  function findConstructs(node, filePaths) {   
     if (node.kind === 0 || node.kind === 1) {
       var children = node.children;
       if (children && children.length > 0) {
@@ -87,7 +87,7 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
       (node.kindString === 'Function' &&
         node.flags.isExported)) && 
         filePaths.find(function(filePath){
-          return filePath.indexOf(node.sources[0].fileName) > -1
+          return node.sources[0].fileName.indexOf(filePath) > -1
         })    
         ) {   
         exportedConstructs.push(node);
@@ -95,6 +95,7 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
     }
   };
   findConstructs(node, filePaths);
+  console.log('Num exportedConstructs '+ exportedConstructs.length);
   return exportedConstructs;
 };
 

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -73,7 +73,7 @@ TSParser.prototype.parse = function() {
 
 TSParser.prototype.findExportedConstructs = function(node, filePaths) {
   var exportedConstructs = [];
-  function findConstructs(node, filePaths) {   
+  function findConstructs(node, filePaths) {
     if (node.kind === 0 || node.kind === 1) {
       var children = node.children;
       if (children && children.length > 0) {
@@ -87,7 +87,9 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
       (node.kindString === 'Function' &&
         node.flags.isExported)) && 
         filePaths.find(function(filePath){
-          return node.sources[0].fileName.indexOf(filePath) > -1
+          if(node.sources[0].fileName.indexOf(filePath) > -1 || filePath.indexOf(node.sources[0].fileName)){
+            return true;
+          }
         })    
         ) {   
         exportedConstructs.push(node);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "marked": "~0.2.9",
     "glob": "3.2.6",
     "underscore.string": "~2.3.3",
-    "typedoc": "0.6.0"
+    "typedoc": "0.7.1"
   },
   "devDependencies": {
     "chai": "^1.9.2",

--- a/templates/tsConstructs/class.ejs
+++ b/templates/tsConstructs/class.ejs
@@ -10,7 +10,7 @@
     <%}%>
 </section>
 <%   
-    const children = children;
+    var children = children || null;
     var properties = [];
     if(children && children.length > 0){
         children.forEach(function(child){

--- a/templates/tsConstructs/class.ejs
+++ b/templates/tsConstructs/class.ejs
@@ -6,6 +6,7 @@
       if(comment){%>
         <div class="code-desc">
             <p><%-comment.shortText%>  </p>
+            <p><%-comment.text%>  </p>
         </div>
     <%}%>
 </section>

--- a/templates/tsConstructs/commaSeperatedParams.ejs
+++ b/templates/tsConstructs/commaSeperatedParams.ejs
@@ -1,18 +1,68 @@
 <%
    var argumentStr = "";
    var params = params || null;
-   var firstParam = true;
-   if(params && params.length > 0){
-       params.forEach(function(param){
-           if(firstParam){
-                firstParam = false;
-                argumentStr = param.name  + ": " + param.type.name;
-           }else{
-                argumentStr = argumentStr + ", " + param.name  + ": " + param.type.name;
-           }
-       });
+   argumentStr = commaSepParams(params);
+
+   function commaSepParams(params){
+    var argumentStr = "";
+    var params = params || null;
+    var firstParam = true;
+    if(params && params.length > 0){
+        params.forEach(function(param){
+            var str = '';
+            if (param.type.type === 'reflection') {
+                str = getSignatureForFunction(param);
+            } else {
+                str = param.name  + ": " + param.type.name;
+            }
+            if(firstParam){
+                    firstParam = false;
+                    argumentStr = str;
+            }else{
+                    argumentStr = argumentStr + ", " + str;
+            }
+        });
+    } 
+    return argumentStr;
    } 
 
-%>
+   function returnTypeStr(type){
+    if(type.type === 'union'){
+      var firstArg = true; 
+      var retStr = '';
+      type.types.forEach(function(typ){ 
+        var str = '';   
+        if(typ.name === 'Promise'){
+            str = typ.name + ' of ' + typ.typeArguments ? typ.typeArguments[0].name : '';
+        }else{
+            str = typ.name;
+        }
+        if(firstArg){
+            retStr = str;
+            firstArg = false;
+        }else{
+            retStr = retStr + ' | ' + str;
+        }
+      });
+      return retStr; 
+    }else{
+      return type.name ; 
+    }
+   }
 
-<%-argumentStr%>
+   function getSignatureForFunction(param){
+    var signatures = param.type.declaration.signatures;   
+    if(signatures && signatures[0]){
+        return param.name + ': ' + '(' + 
+        commaSepParams(signatures[0].parameters) + ') => '
+            +
+        returnTypeStr(signatures[0].type);
+    }else{
+        return param.name;
+    }
+
+   }
+
+
+%>
+    <%-argumentStr%>

--- a/templates/tsConstructs/commaSeperatedParams.ejs
+++ b/templates/tsConstructs/commaSeperatedParams.ejs
@@ -31,9 +31,9 @@
       var firstArg = true; 
       var retStr = '';
       type.types.forEach(function(typ){ 
-        var str = '';   
+        var str = '';  
         if(typ.name === 'Promise'){
-            str = typ.name + ' of ' + typ.typeArguments ? typ.typeArguments[0].name : '';
+            str = (typ.name + ' of ') + (typ.typeArguments ? typ.typeArguments[0].name : '');
         }else{
             str = typ.name;
         }

--- a/templates/tsConstructs/constructor.ejs
+++ b/templates/tsConstructs/constructor.ejs
@@ -16,6 +16,7 @@
           var comment = comment || (signatures && signatures[0] && signatures[0].comment) || null;
           if(comment){%>
             <p><%-comment.shortText%></p>
+            Returns: <p><%-comment.returns%></p>
         <%}%>
     </div>
 <%

--- a/templates/tsConstructs/constructor.ejs
+++ b/templates/tsConstructs/constructor.ejs
@@ -23,7 +23,6 @@
     if(signatures){ 
     const parameters = signatures[0].parameters;
     if(parameters && parameters.length > 0){
-        parameters.forEach(function(param){
 %>
     <div class="code-arguments-hdr">Arguments</div>
     <table class="params code-arguments">
@@ -32,6 +31,9 @@
             <th class="hdr-type">Type</th>
             <th class="hdr-desc">Description</th>
         </tr>
+<%        
+        parameters.forEach(function(param){
+%>        
             <tr class="code-arg">
                 <td>
                     <strong class="code-arg-name"><%-param.name%></strong>
@@ -47,9 +49,11 @@
                     <%}%>
                 </td>
             </tr>
-    </table>
-<%            
+ <%            
         });
+%>           
+    </table>
+<%        
     }
     } 
 %>

--- a/templates/tsConstructs/constructor.ejs
+++ b/templates/tsConstructs/constructor.ejs
@@ -16,8 +16,14 @@
           var comment = comment || (signatures && signatures[0] && signatures[0].comment) || null;
           if(comment){%>
             <p><%-comment.shortText%></p>
+            <p><%-comment.text%></p>
+        <%}
+          if(comment && comment.returns){
+        %>
             Returns: <p><%-comment.returns%></p>
-        <%}%>
+        <%    
+          }  
+        %>
     </div>
 <%
     if(signatures){ 

--- a/templates/tsConstructs/constructor.ejs
+++ b/templates/tsConstructs/constructor.ejs
@@ -1,6 +1,16 @@
 <section class="code-doc ">
     <a name="<%-anchorId%>"></a>
-    <h4 class="code-ref"><%-name%>(<%- include('commaSeperatedParams', {'params': signatures[0].parameters}); %>): <%-signatures[0].type.name%></h4>
+<%
+  if (signatures[0].type.type === 'reference') {
+%>
+  <h4 class="code-ref"><%-name%>(<%- include('commaSeperatedParams', {'params': signatures[0].parameters}); %>): <a href="#<%-signatures[0].type.name%>"><%-signatures[0].type.name%></a></h4>
+<%
+  } else {
+%>
+  <h4 class="code-ref"><%-name%>(<%- include('commaSeperatedParams', {'params': signatures[0].parameters}); %>): <%-signatures[0].type.name%></h4>  
+<%
+  }
+%>    
     <div class="code-desc">
         <%
           var comment = comment || (signatures && signatures[0] && signatures[0].comment) || null;
@@ -26,12 +36,12 @@
                     <strong class="code-arg-name"><%-param.name%></strong>
                 </td>
                 <td class="code-arg-types">
-                    <code><%-param.type.name%></code>
+                    <%- include('type', param); %>
                 </td>
                 <td class="code-arg-desc">
                     <%if(param.comment){%>
                         <div class="code-desc">
-                            <p><%-param.comment.shortText%></p>
+                            <p><%-param.comment.text%></p>
                         </div>
                     <%}%>
                 </td>

--- a/templates/tsConstructs/constructor.ejs
+++ b/templates/tsConstructs/constructor.ejs
@@ -44,12 +44,13 @@
                 <td class="code-arg-desc">
                     <%if(param.comment){%>
                         <div class="code-desc">
+                            <p><%-param.comment.shortText%></p>
                             <p><%-param.comment.text%></p>
                         </div>
                     <%}%>
                 </td>
             </tr>
- <%            
+<%            
         });
 %>           
     </table>

--- a/templates/tsConstructs/interface.ejs
+++ b/templates/tsConstructs/interface.ejs
@@ -24,10 +24,10 @@
 <% 
         }
         children.forEach(function(child){
-            if(child.kindString === 'Constructor'){%>
+            if(child.kindString === 'Constructor' && child.shouldDocument){%>
                  <%- include('constructor', child); %>
             <%}
-            if(child.kindString === 'Method' && !child.flags.isPrivate){%>
+            if(child.kindString === 'Method' && child.shouldDocument){%>
                 <%- include('function', child); %>
             <%}
         })

--- a/templates/tsConstructs/interface.ejs
+++ b/templates/tsConstructs/interface.ejs
@@ -10,7 +10,7 @@
     <%}%>
 </section>
 <%   
-    const children = children;
+    var children = children || null;
     var properties = [];
     if(children && children.length > 0){
         children.forEach(function(child){

--- a/templates/tsConstructs/properties.ejs
+++ b/templates/tsConstructs/properties.ejs
@@ -17,7 +17,7 @@
                     <strong class="code-arg-name"><%-param.name%></strong>
                 </td>
                 <td class="code-arg-types">
-                    <code><%-param.type.name%></code>
+                    <%- include('type', param); %>
                 </td>
                 <td class="code-arg-desc">
                     <%if(param.comment){%>

--- a/templates/tsConstructs/type.ejs
+++ b/templates/tsConstructs/type.ejs
@@ -3,6 +3,10 @@
 %>
   <code><a href="#<%-type.name%>"><%-type.name%></a></code>
 <%
+  } else if (type.type === 'reflection'){
+%> 
+  <code>Function</code>
+<%
   } else {
 %>
   <code><%-type.name%></code>

--- a/templates/tsConstructs/type.ejs
+++ b/templates/tsConstructs/type.ejs
@@ -1,0 +1,11 @@
+<%
+  if (type.type === 'reference') {
+%>
+  <code><a href="#<%-type.name%>"><%-type.name%></a></code>
+<%
+  } else {
+%>
+  <code><%-type.name%></code>
+<%
+  }
+%>

--- a/templates/tsConstructs/typeAlias.ejs
+++ b/templates/tsConstructs/typeAlias.ejs
@@ -1,0 +1,28 @@
+ <%
+  if(type.type === 'intrinsic'){
+%> 
+<section class="code-doc ">
+    <a name="<%-anchorId%>"></a>    
+    <h4 class="code-ref"><%-name%> = <%-type.name%></h4> 
+</section>    
+<%
+  } else if (type.type === 'array'){
+%> 
+<section class="code-doc ">
+    <a name="<%-anchorId%>"></a>    
+    <h4 class="code-ref"><%-name%> = <%-type.elementType.name%>[]</h4> 
+</section>   
+<%
+  } else if (type.type === 'reference'){
+%>    
+<section class="code-doc ">
+    <a name="<%-anchorId%>"></a>    
+    <h4 class="code-ref"><%-name%> = <%-type.name%></h4> 
+</section>    
+<%
+  } else if (type.type === 'reflection'){
+%>
+    <% include typeAliasReflection %>
+<%
+  }
+%>

--- a/templates/tsConstructs/typeAliasReflection.ejs
+++ b/templates/tsConstructs/typeAliasReflection.ejs
@@ -16,7 +16,19 @@
 %> 
     <div class="code-desc">
         <%
-          var comment = signature.comment || null;
+          var comment = comment || comment_copy || signature.comment || null;
+            var commentsMap;
+            if(comment && comment.tags){
+                commentsMap = [];
+                comment.tags.forEach(function(tag){
+                    if(tag.tag === 'param'){
+                        commentsMap[tag.param] = tag.text;
+                    }
+                    if(tag.tag === 'returns'){
+                        commentsMap[tag.tag] = tag.text;
+                    }
+                });   
+            }
           if(comment){%>
             <p><%-comment.shortText%></p>
             <p><%-comment.text%></p>
@@ -25,7 +37,11 @@
         %>
             Returns: <p><%-comment.returns%></p>
         <%    
-          }  
+          } else if(commentsMap){
+        %>   
+            Returns: <p><%-commentsMap['returns']%></p>   
+        <%
+          }
         %>
     </div>
 <%
@@ -54,6 +70,10 @@
                         <div class="code-desc">
                             <p><%-param.comment.shortText%></p>
                             <p><%-param.comment.text%></p>
+                        </div>
+                    <%} else if(commentsMap){%>
+                        <div class="code-desc">
+                            <p><%-commentsMap[param.name]%></p>
                         </div>
                     <%}%>
                 </td>

--- a/templates/tsConstructs/typeAliasReflection.ejs
+++ b/templates/tsConstructs/typeAliasReflection.ejs
@@ -1,25 +1,22 @@
 <section class="code-doc ">
     <a name="<%-anchorId%>"></a>
 <%
-if(signatures && signatures[0]){
-    if (signatures[0].type.type === 'reference') {
-    %>
-    <h4 class="code-ref"><%-name%> (<%- include('commaSeperatedParams', {'params': signatures[0].parameters}); %>): <a href="#<%-signatures[0].type.name%>"><%-signatures[0].type.name%></a></h4>
-    <%
-    } else {
-    %>
-    <h4 class="code-ref"><%-name%> (<%- include('commaSeperatedParams', {'params': signatures[0].parameters}); %>): <%-signatures[0].type.name%></h4>  
-    <%
-    }
-} else {
-%> 
-    <h4 class="code-ref"><%-name%></h4>
+  if(type && type.declaration && (type.declaration.signatures || type.declaration.indexSignature)){
+  var signature = (type.declaration.signatures && type.declaration.signatures[0]) ||
+                  (type.declaration.indexSignature && type.declaration.indexSignature[0]);
+    if (signature.type.type === 'reference') {
+%>
+      <h4 class="code-ref"><%-name%>(<%- include('commaSeperatedParams', {'params': signature.parameters}); %>): <a href="#<%-signature.type.name%>"><%-signature.type.name%></a></h4>
 <%
-}
-%>  
+    } else {
+%>
+      <h4 class="code-ref"><%-name%>(<%- include('commaSeperatedParams', {'params': signature.parameters}); %>): <%-signature.type.name%></h4>  
+<%
+    }
+%> 
     <div class="code-desc">
         <%
-          var comment = comment || (signatures && signatures[0] && signatures[0].comment) || null;
+          var comment = signature.comment || null;
           if(comment){%>
             <p><%-comment.shortText%></p>
             <p><%-comment.text%></p>
@@ -32,8 +29,7 @@ if(signatures && signatures[0]){
         %>
     </div>
 <%
-    if(signatures){ 
-    const parameters = signatures[0].parameters;
+    const parameters = signature.parameters;
     if(parameters && parameters.length > 0){
 %>
     <div class="code-arguments-hdr">Arguments</div>
@@ -68,6 +64,6 @@ if(signatures && signatures[0]){
     </table>
 <%        
     }
-    } 
-%>
+  }
+%> 
 </section>

--- a/test/ts-parser.test.js
+++ b/test/ts-parser.test.js
@@ -8,7 +8,9 @@ describe('TypeScript Parser Test', function() {
 
   it('should parse this TS file', function(done) {
     var file = path.join(__dirname, 'fixtures' , 'ts', 'Greeter.ts');
-    var tsParser = new TSParser(file);
+    var tsFiles = [];
+    tsFiles.push(file);
+    var tsParser = new TSParser(tsFiles);
     var parsedData = tsParser.parse();
     assert.equal(parsedData.sections.length, 3);
     assert.equal(parsedData.constructs.length, 1);


### PR DESCRIPTION
This is the PR for stories strongloop-internal/scrum-asteroid#219 and strongloop-internal/scrum-asteroid#221
 - Added support for markdown processing, code highlighting, and provision for writing example code
- Added links to Types (only works within a package. @TODO: across the packages reference need to thought of)
- Also did refactoring to process all TS files together, which is an appropriate thing to do, given the way typeDoc works, instead of processing them one at a time.

![image](https://user-images.githubusercontent.com/24725376/27234418-d12b79aa-5271-11e7-89cb-9b54ca28ba80.png)
 