### PR TITLE
Drop support for Node.js version pre-4.0 in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - "4"
   - "6"
   - "8"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "strong-docs",
   "description": "Sleek, intuitive, and powerful documentation site generator",
   "version": "1.4.0",
+  "engines": {
+    "node": ">=4"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/strongloop/strong-docs.git"


### PR DESCRIPTION
This is just a formal change, the support was effectively dropped when we added typedoc dependency.