### PR TITLE
Upgrade to typedoc@0.9.0 to support TS 2.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "marked": "~0.2.9",
     "optimist": "~0.6.0",
     "strong-task-emitter": "~0.0.5",
-    "typedoc": "0.7.1",
+    "typedoc": "^0.9.0",
     "underscore.string": "^3.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

TypeScript 2.4 introduces string enums. The v0.7.0 of typedoc is broken.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/issues/622

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
