### PR TITLE
feat: allow tsconfig/tstarget for typedoc

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,6 +10,8 @@ var configPaths = {};
 var configPath = argv.config || argv.c || 'docs.json';
 var config;
 var outputPath = argv.out || argv.o;
+var tsConfig = argv.tsconfig;
+var tsTarget = argv.tstarget;
 var previewMode = argv.preview || argv.p;
 var packagePath = argv.package || 'package.json';
 var package;
@@ -76,6 +78,12 @@ if(previewMode) {
 
     Docs.readConfig(configPaths, function(err, config) {
       if (err) return next(err);
+      if (tsConfig) {
+        config.tsconfig = tsConfig;
+      }
+      if (tsTarget) {
+        config.tstarget = tsTarget;
+      }
       var assets = getAssetData(config);
 
       if(assets) {
@@ -121,6 +129,16 @@ if(outputPath) {
   fs.copySync(publicAssets, outputPath);
 
   Docs.readConfig(configPaths, function(err, config) {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+    if (tsConfig) {
+      config.tsconfig = tsConfig;
+    }
+    if (tsTarget) {
+      config.tstarget = tsTarget;
+    }
     var assets = getAssetData(config);
 
     if(assets) {

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -8,4 +8,6 @@ Arguments:
   --out, -o       Output path for generated docs directory
   --preview, -p   Start a preview server
   --port          Specify the preview server port
+  --tsconfig      Specify the tsconfig option for typescript
+  --tstarget      Specify the target for typescript
   --help, -h      Print this help text

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -13,26 +13,49 @@ marked.setOptions({
   }
 });
 
-var app = new typedoc.Application({
-  mode: 'Modules',
-  logger: 'console',
-  target: 'ES6',
-  module: 'CommonJS',
-  experimentalDecorators: true,
-  includeDeclarations: true,
-});
-
-function TSParser(filePaths) {
+function TSParser(filePaths, config) {
   this.filePaths = filePaths;
   this.sections = [];
   this.constructs = [];
+  config = config || {};
+  var options = {
+    mode: 'Modules',
+    logger: 'console',
+    target: config.tstarget || 'ES6',
+    module: 'CommonJS',
+    experimentalDecorators: true,
+    includeDeclarations: true,
+  };
+  if (config.tsconfig) {
+    options.tsconfig = config.tsconfig;
+  }
+  this.app = new typedoc.Application(options);
+}
+
+// Override typedoc.Application.convert() to get errors
+function convert(app, src) {
+  app.logger.writeln(
+    "Using TypeScript %s from %s",
+    app.getTypeScriptVersion(),
+    app.getTypeScriptPath()
+  );
+
+  var result = app.converter.convert(src);
+  if (result.errors && result.errors.length) {
+    app.logger.diagnostics(result.errors);
+    if (app.ignoreCompilerErrors) {
+      app.logger.resetErrors();
+    } 
+  } 
+  return result;
 }
 
 TSParser.prototype.parse = function() {
-  var project = app.convert(this.filePaths);
+  var result = convert(this.app, this.filePaths);
+  var project = result.project;
   
-  if (!project) {
-    console.log('Could not create project for file: ' + this.filename);
+  if (result.errors && result.errors.length) {
+    this.app.logger.error('TypeScript compilation fails. See error messages in the log above.');
   } else {
     var exportedConstructs = this.findExportedConstructs(project.toObject(), this.filePaths);
     exportedConstructs.forEach(function(node) {
@@ -69,7 +92,7 @@ TSParser.prototype.parse = function() {
       }
     }.bind(this));
   }
-  return {'sections': this.sections, 'constructs': this.constructs};
+  return {sections: this.sections, constructs: this.constructs, errors: result.errors};
 };
 
 TSParser.prototype.findExportedConstructs = function(node, filePaths) {
@@ -99,7 +122,6 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
     }
   };
   findConstructs(node, filePaths);
-  console.log('Num exportedConstructs '+ exportedConstructs.length);
   return exportedConstructs;
 };
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "test": "mocha"
   },
   "dependencies": {
-    "debug": "^2.6.8",
-    "dox": "0.8.0",
+    "debug": "^3.1.0",
+    "dox": "^0.9.0",
     "ejs": "~2.5.6",
     "express": "^4.15.3",
-    "fs-extra": "^4.0.0",
+    "fs-extra": "^5.0.0",
     "glob": "^7.1.2",
-    "highlight.js": "~7.3.0",
+    "highlight.js": "^9.12.0",
     "markdown": "~0.5.0",
     "marked": "^0.3.7",
     "optimist": "~0.6.0",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.4.2"
+    "mocha": "^5.0.0"
   },
   "bin": {
     "sdocs": "./bin/cli.js"

--- a/test/fixtures/ts/Greeter.es2016.ts
+++ b/test/fixtures/ts/Greeter.es2016.ts
@@ -1,0 +1,26 @@
+/** Class representing a greeter. */
+export class Greeter {
+  /**
+   * constructor comments
+   * @param names An array of valid names
+   */
+  constructor(private names: string[]) {
+    this.names = names;
+  }
+  greet(name: string) {
+    if (this.isValid(name)) {
+      return "Hello, " + name;
+    } else {
+      return "Sorry, " + name;
+    }
+  }
+
+  private isValid(name: string) {
+      // `includes` is only available since ES2016
+    return this.names.includes(name);
+  }
+}
+
+let greeter = new Greeter(["John", "Mary"]);
+greeter.greet("John");
+greeter.greet("Smith");

--- a/test/ts-parser.test.js
+++ b/test/ts-parser.test.js
@@ -5,16 +5,28 @@ var expect = require('chai').expect;
 var TSParser = require('../lib/tsParser');
 
 describe('TypeScript Parser Test', function() {
+  var tsOptions = {tsconfig: path.join(__dirname, 'tsconfig.json')};
 
   it('should parse this TS file', function() {
-    this.timeout(50000);
-    var file = path.join(__dirname, 'fixtures' , 'ts', 'Greeter.ts');
-    var tsFiles = [];
-    tsFiles.push(file);
-    var tsParser = new TSParser(tsFiles);
+    this.timeout(90000); // typedoc can be time consuming
+    var file = path.join(__dirname, 'fixtures/ts/Greeter.ts');
+    var tsFiles = [file];
+    var tsParser = new TSParser(tsFiles, tsOptions);
     var parsedData = tsParser.parse();
     assert.equal(parsedData.sections.length, 3);
     assert.equal(parsedData.constructs.length, 1);
+  });
+
+  it('should report errors based on tsconfig', function() {
+    this.timeout(90000);
+    var file = path.join(__dirname, 'fixtures/ts/Greeter.es2016.ts');
+    var tsFiles = [file];
+    var tsParser = new TSParser(tsFiles, tsOptions);
+    var parsedData = tsParser.parse();
+    expect(parsedData.errors).have.property('length', 1);
+    expect(parsedData.errors[0].messageText).to.eql(
+      'Property \'includes\' does not exist on type \'string[]\'.'
+    );
   });
 
 });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+
+    "lib": ["es2015", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es6",
+    "sourceMap": true,
+    "declaration": true
+  },
+  "include": [
+    "fixures/ts"
+  ]
+}


### PR DESCRIPTION
### Description

This PR allows `tsconfig` and `tstarget` options to be passed to typedoc so that we can leverage project level settings for strong-docs. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
