### PR TITLE
fix: make sure options from cli/docs.json are passed to typedoc

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -78,12 +78,7 @@ if(previewMode) {
 
     Docs.readConfig(configPaths, function(err, config) {
       if (err) return next(err);
-      if (tsConfig) {
-        config.tsconfig = tsConfig;
-      }
-      if (tsTarget) {
-        config.tstarget = tsTarget;
-      }
+      config = configureTypeDoc(config);
       var assets = getAssetData(config);
 
       if(assets) {
@@ -133,12 +128,7 @@ if(outputPath) {
       console.error(err);
       process.exit(1);
     }
-    if (tsConfig) {
-      config.tsconfig = tsConfig;
-    }
-    if (tsTarget) {
-      config.tstarget = tsTarget;
-    }
+    config = configureTypeDoc(config);
     var assets = getAssetData(config);
 
     if(assets) {
@@ -166,3 +156,21 @@ if(outputPath) {
     });
   });
 }
+
+/**
+ * Configure options for TypeDoc
+ * @param {*} config 
+ */
+function configureTypeDoc(config) {
+  config = config || {};
+  config.typedoc = config.typedoc || {};
+  var typeDocOptions = config.typedoc;
+  if (tsConfig) {
+    typeDocOptions.tsconfig = tsConfig;
+  }
+  if (tsTarget) {
+    typeDocOptions.target = tsTarget;
+  }
+  return config;
+}
+

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -186,7 +186,7 @@ Docs.prototype.parse = function (fn) {
     }.bind(this));
     // Process ts files
     if(tsFiles.length > 0) {
-      var tsParser = new TSParser(tsFiles);
+      var tsParser = new TSParser(tsFiles, this.config.typedoc);
       var parsedData = tsParser.parse();
       var doc = {
         classes: parsedData.constructs,

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -19,15 +19,17 @@ function TSParser(filePaths, config) {
   this.constructs = [];
   config = config || {};
   var options = {
-    mode: 'Modules',
+    mode: 'modules',
     logger: 'console',
-    target: config.tstarget || 'ES6',
-    module: 'CommonJS',
+    target: config.target || 'ES6',
+    module: 'commonjs',
     experimentalDecorators: true,
     includeDeclarations: true,
   };
-  if (config.tsconfig) {
-    options.tsconfig = config.tsconfig;
+  for (var i in config) {
+    if (config[i] !== undefined) {
+      options[i] = config[i];
+    }
   }
   this.app = new typedoc.Application(options);
 }

--- a/test/ts-parser.test.js
+++ b/test/ts-parser.test.js
@@ -13,8 +13,9 @@ describe('TypeScript Parser Test', function() {
     var tsFiles = [file];
     var tsParser = new TSParser(tsFiles, tsOptions);
     var parsedData = tsParser.parse();
-    assert.equal(parsedData.sections.length, 3);
-    assert.equal(parsedData.constructs.length, 1);
+    expect(parsedData.sections).to.have.length(3);
+    expect(parsedData.constructs).to.have.length(1);
+    expect(parsedData.errors).to.have.length(0);
   });
 
   it('should report errors based on tsconfig', function() {
@@ -23,10 +24,21 @@ describe('TypeScript Parser Test', function() {
     var tsFiles = [file];
     var tsParser = new TSParser(tsFiles, tsOptions);
     var parsedData = tsParser.parse();
-    expect(parsedData.errors).have.property('length', 1);
+    expect(parsedData.errors).to.have.length(1);
     expect(parsedData.errors[0].messageText).to.eql(
       'Property \'includes\' does not exist on type \'string[]\'.'
     );
+  });
+
+  it('should parse Array.includes with es2016', function() {
+    this.timeout(90000);
+    var file = path.join(__dirname, 'fixtures/ts/Greeter.es2016.ts');
+    var tsFiles = [file];
+    var tsParser = new TSParser(tsFiles, {target: 'es2016'});
+    var parsedData = tsParser.parse();
+    expect(parsedData.sections).to.have.length(3);
+    expect(parsedData.constructs).to.have.length(1);
+    expect(parsedData.errors).to.have.length(0);
   });
 
 });


### PR DESCRIPTION
### Description

This is a follow-up to #103, which doesn't pass into CLI options to TypeDoc.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
