### PR TITLE
fix: make sure absolute paths are passed to typedoc

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -166,12 +166,12 @@ Docs.prototype.parse = function (fn) {
         var fauxdoc = new Doc('faux-section.md', contents, false, this);
         this.content.push(fauxdoc);
       } else {
-          if (path.extname(f) === '.ts') {
-            // Filter out ts files, and process them as a bunch
-            tsFiles.push(f);
-            return;
-          }
         f = path.resolve(root, f);
+        if (path.extname(f) === '.ts') {
+          // Filter out ts files, and process them as a bunch
+          tsFiles.push(f);
+          return;
+        }
         contents = files[f];
         if(this.hasExt(f)) { 
           var doc = new Doc(f, contents, path.extname(f) === '.js', self);

--- a/test/docs.test.js
+++ b/test/docs.test.js
@@ -7,7 +7,8 @@ var SAMPLE = [
   'fixtures/a.md',
   'fixtures/b/b.md',
   'fixtures/b/*.js',
-  'fixtures/b/c/c.md'
+  'fixtures/b/c/c.md',
+  'fixtures/ts/Greeter.ts'
 ];
 var Docs = require('../');
 
@@ -18,7 +19,7 @@ describe('Docs', function() {
       content: SAMPLE,
       root: __dirname
     }, function (err, docs) {
-      assert.equal(docs.content.length, 4);
+      assert.equal(docs.content.length, 5);
       done();
     });
   });
@@ -28,7 +29,7 @@ describe('Docs', function() {
       content: SAMPLE,
       root: __dirname
     }, function (err, docs) {
-      assert.equal(docs.sections.length, 8);
+      assert.equal(docs.sections.length, 11);
       done();
     });
   });
@@ -42,7 +43,7 @@ describe('Docs', function() {
     });
   });
 
-  it('should inclide documentation from external file', function(done) {
+  it('should include documentation from external file', function(done) {
     Docs.toHtml({
       content: ['fixtures/js/main-class.js', 'fixtures/js/class-method.js'],
       root: __dirname


### PR DESCRIPTION
Typedoc uses the absolute path to check if a file is external

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
