### PR TITLE
fix: fix typedoc for type alias

### DIFF
--- a/templates/tsConstructs/typeAliasReflection.ejs
+++ b/templates/tsConstructs/typeAliasReflection.ejs
@@ -3,7 +3,7 @@
 <%
     if(type && type.declaration && (type.declaration.signatures || type.declaration.indexSignature)){
     var signature = (type.declaration.signatures && type.declaration.signatures[0]) ||
-                  (type.declaration.indexSignature && type.declaration.indexSignature[0]);              
+                  (type.declaration.indexSignature);
     if (signature.type.type === 'reference' && signature.type.name !== 'Promise') {
 %>
         <h4 class="code-ref"><%-name%>(<%-tsHelpers.commaSepParams(signature.parameters)%>): <a href="#<%-signature.type.name%>"><%-signature.type.name%></a></h4>

--- a/test/docs.test.js
+++ b/test/docs.test.js
@@ -29,7 +29,7 @@ describe('Docs', function() {
       content: SAMPLE,
       root: __dirname
     }, function (err, docs) {
-      assert.equal(docs.sections.length, 11);
+      assert.equal(docs.sections.length, 12);
       done();
     });
   });

--- a/test/fixtures/ts/Greeter.ts
+++ b/test/fixtures/ts/Greeter.ts
@@ -17,3 +17,5 @@ function greeterFun(age: number){
 }
 
 let greeter = new Greeter("world");
+
+export type PathParameterValues = {[key: string]: any};

--- a/test/ts-parser.test.js
+++ b/test/ts-parser.test.js
@@ -16,8 +16,8 @@ describe('TypeScript Parser Test', function() {
       tsconfig,
     });
     var parsedData = tsParser.parse();
-    expect(parsedData.sections).to.have.length(3);
-    expect(parsedData.constructs).to.have.length(1);
+    expect(parsedData.sections).to.have.length(4);
+    expect(parsedData.constructs).to.have.length(2);
     expect(parsedData.errors).to.have.length(0);
   });
 


### PR DESCRIPTION
### Description

Allow `export type PathParameterValues = {[key: string]: any};`

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
