### PR TITLE
fix: handle typescript namespaces

### DIFF
--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -57,15 +57,15 @@ function convert(app, src) {
     app.logger.diagnostics(result.errors);
     if (app.ignoreCompilerErrors) {
       app.logger.resetErrors();
-    } 
-  } 
+    }
+  }
   return result;
 }
 
 TSParser.prototype.parse = function() {
   var result = convert(this.app, this.filePaths);
   var project = result.project;
-  
+
   if (result.errors && result.errors.length) {
     this.app.logger.error('TypeScript compilation fails. See error messages in the log above.');
   } else {
@@ -91,7 +91,7 @@ TSParser.prototype.parse = function() {
               (child.kindString === 'Property' && !child.inheritedFrom && !child.flags.isPrivate && !child.flags.isProtected) ||
               (child.kindString === 'Constructor' && !child.inheritedFrom) ||
               (child.kindString === 'Method' && !child.inheritedFrom && !child.flags.isPrivate && !child.flags.isProtected)
-              ) {   
+              ) {
              // This is needed in UI, good to keep the elibility logic at one place
               child.shouldDocument = true;
               processMarkdown(child);
@@ -111,12 +111,17 @@ TSParser.prototype.parse = function() {
 
 TSParser.prototype.findExportedConstructs = function(node, filePaths) {
   var exportedConstructs = [];
-  function findConstructs(node, filePaths) {
-    if (node.kind === 0 || node.kind === 1) {
+  function findConstructs(node, filePaths, parent) {
+    // Global = 0, ExternalModule = 1, Module = 2, ObjectLiteral = 2097152,
+    if (node.kind === 0 || node.kind === 1 || node.kind === 2 || node.kind === 2097152) {
       var children = node.children;
       if (children && children.length > 0) {
+        if (node.kind === 2 || node.kind === 2097152) {
+          // Keep track of namespaces and object literals
+          parent = parent? parent + '.' + node.name : node.name;
+        }
         children.forEach(function(child) {
-          findConstructs(child, filePaths);
+          findConstructs(child, filePaths, parent);
         });
       }
     } else {
@@ -124,13 +129,14 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
       node.kindString === 'Interface' ||
       node.kindString === 'Type alias' ||
       (node.kindString === 'Function' &&
-        node.flags.isExported)) && 
+        node.flags.isExported)) &&
         filePaths.find(function(filePath){
           if(node.sources[0].fileName.split("/").pop() === filePath.split("/").pop()){
             return true;
           }
-        })    
-        ) {   
+        })
+        ) {
+        node.name = parent? parent + '.' + node.name : node.name;
         exportedConstructs.push(node);
       }
     }
@@ -145,7 +151,7 @@ function createAnchor(node) {
     node.anchorId = node.name;
   } else {
     node.anchorId = node.id;
-  } 
+  }
 };
 
 function processMarkdown(node) {

--- a/test/docs.test.js
+++ b/test/docs.test.js
@@ -29,7 +29,7 @@ describe('Docs', function() {
       content: SAMPLE,
       root: __dirname
     }, function (err, docs) {
-      assert.equal(docs.sections.length, 12);
+      assert.equal(docs.sections.length, 15);
       done();
     });
   });

--- a/test/fixtures/ts/Greeter.ts
+++ b/test/fixtures/ts/Greeter.ts
@@ -3,8 +3,8 @@ export class Greeter {
     greeting: string;
     greeting2: number;
     /**
-    * constructor comments	
-    */	
+     * constructor comments
+     */
     constructor(message: string) {
         this.greeting = message;
     }
@@ -19,3 +19,22 @@ function greeterFun(age: number){
 let greeter = new Greeter("world");
 
 export type PathParameterValues = {[key: string]: any};
+
+export function param() {}
+
+/**
+ * namespace comments
+ */
+export namespace param {
+  /**
+   * interface comments
+   */
+  export interface Message {
+    body: string;
+  }
+
+  export const path = {
+    number: function() {},
+    boolean: function() {},
+  }
+}

--- a/test/ts-parser.test.js
+++ b/test/ts-parser.test.js
@@ -16,8 +16,12 @@ describe('TypeScript Parser Test', function() {
       tsconfig,
     });
     var parsedData = tsParser.parse();
-    expect(parsedData.sections).to.have.length(4);
-    expect(parsedData.constructs).to.have.length(2);
+    expect(parsedData.sections).to.have.length(7);
+    expect(parsedData.constructs).to.have.length(5);
+    expect(parsedData.constructs.map(function(c) {
+      return c.node.name;
+    })).to.eql(['param.Message', 'param.path.boolean', 'param.path.number',
+      'Greeter', 'PathParameterValues']);
     expect(parsedData.errors).to.have.length(0);
   });
 


### PR DESCRIPTION
### Description

This PR fixes parsing of TypeScript namespaces.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/issues/584

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
