### PR TITLE
Allow TS variables to be documented

### DIFF
--- a/lib/tsConstruct.js
+++ b/lib/tsConstruct.js
@@ -6,11 +6,13 @@ var ejs = require('ejs'),
   fs = require('fs'),
   path = require('path'),
   tsHelpers = require('./tsHelpers'),
-  TS_CLASS_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'class.ejs'),
-  TS_INTERFACE_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'interface.ejs'),
-  TS_OBJECT_LITERAL_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'objectLiteral.ejs'),
-  TS_FUNCTION_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'function.ejs'),
-  TS_TYPE_ALIAS_TEMPLATE = path.join(__dirname, '..', 'templates', 'tsConstructs', 'typeAlias.ejs');
+  TS_CLASS_TEMPLATE = path.join(__dirname, '../templates/tsConstructs/class.ejs'),
+  TS_INTERFACE_TEMPLATE = path.join(__dirname, '../templates/tsConstructs/interface.ejs'),
+  TS_OBJECT_LITERAL_TEMPLATE = path.join(__dirname, '../templates/tsConstructs/objectLiteral.ejs'),
+  TS_VARIABLE_TEMPLATE = path.join(__dirname, '../templates/tsConstructs/variable.ejs'),
+  TS_NAMESPACE_TEMPLATE = path.join(__dirname, '../templates/tsConstructs/namespace.ejs'),
+  TS_FUNCTION_TEMPLATE = path.join(__dirname, '../templates/tsConstructs/function.ejs'),
+  TS_TYPE_ALIAS_TEMPLATE = path.join(__dirname, '../templates/tsConstructs/typeAlias.ejs');
 
 function TSConstruct(node) {
   this.node = node;
@@ -35,6 +37,14 @@ function TSConstruct(node) {
       filename: TS_OBJECT_LITERAL_TEMPLATE,
       file: fs.readFileSync(TS_OBJECT_LITERAL_TEMPLATE, 'utf8'),
     },
+    'module': {
+      filename: TS_NAMESPACE_TEMPLATE,
+      file: fs.readFileSync(TS_NAMESPACE_TEMPLATE, 'utf8'),
+    },
+    'variable': {
+      filename: TS_VARIABLE_TEMPLATE,
+      file: fs.readFileSync(TS_VARIABLE_TEMPLATE, 'utf8'),
+    },
   };
 }
 
@@ -47,7 +57,7 @@ TSConstruct.prototype.render = function() {
   this.node.tsHelpers = tsHelpers;
   // HACK: for some reason "comment" is not getting passed in EJS include
   // May be it is a keyword and treated differently, should copy it in
-  // to another varaible comment_copy that gets passed on to included template.          
+  // to another varaible comment_copy that gets passed on to included template.
   this.node.comment_copy = this.node.comment;
   return ejs.render(
     this.templates[this.node.kindString.toLowerCase()].file, this.node

--- a/lib/tsHelpers.js
+++ b/lib/tsHelpers.js
@@ -69,4 +69,48 @@ tsHelpers.getSignatureForFunction = function(param) {
   }
 }
 
+/**
+ * Get flags as a string
+ *
+ * - Private
+ * - Protected
+ * - Static
+ * - ExportAssignment
+ * - Optional
+ * - DefaultValue
+ * - Rest
+ * - Abstract
+ * - Let
+ * - Const
+ *
+ * @param {*} flags
+ */
+tsHelpers.getFlags = function (flags) {
+  flags = flags || {};
+  var names = [];
+  for (var f in flags) {
+    if (flags[f]) {
+      if (f.indexOf('is') === 0) {
+        f = f.substr(2);
+        f = f[0].toLowerCase() + f.substr(1);
+      }
+      names.push(f);
+    }
+  }
+  return names.join(' ');
+}
+
+/**
+ * Get variable type as Const/Let/Variable
+ * @param {*} varNode
+ */
+tsHelpers.getVariableType = function (varNode) {
+  var kind = varNode.kindString;
+  if (varNode.flags) {
+    if (varNode.flags.isConst) kind = 'Const';
+    if (varNode.flags.isLet) kind = 'Let';
+  }
+  return kind;
+}
+
 module.exports = tsHelpers;

--- a/lib/tsParser.js
+++ b/lib/tsParser.js
@@ -5,6 +5,7 @@ module.exports = TSParser;
 var typedoc = require('typedoc'),
   path = require('path'),
   TSConstruct = require('./tsConstruct'),
+  tsHelpers = require('./tsHelpers'),
   marked = require('marked');
 
 marked.setOptions({
@@ -47,7 +48,7 @@ function TSParser(filePaths, config) {
 // Override typedoc.Application.convert() to get errors
 function convert(app, src) {
   app.logger.writeln(
-    "Using TypeScript %s from %s",
+    'Using TypeScript %s from %s',
     app.getTypeScriptVersion(),
     app.getTypeScriptPath()
   );
@@ -77,15 +78,21 @@ TSParser.prototype.parse = function() {
           node.kindString === 'Interface' ||
           node.kindString === 'Function' ||
           node.kindString === 'Object literal' ||
+          node.kindString === 'Module' ||
+          node.kindString === 'Variable' ||
           node.kindString === 'Type alias') {
             processMarkdown(node);
             this.constructs.push(new TSConstruct(node));
             createAnchor(node);
-            this.sections.push({'title': node.kindString + ': ' + node.name,
+            var kind = node.kindString;
+            if (kind === 'Module') kind = 'Namespace';
+            if (kind === 'Variable') kind = tsHelpers.getVariableType(node);
+            this.sections.push({'title': kind + ': ' + node.name,
           'anchor': node.anchorId, 'depth': 3});
         // build sections for children
         var children = node.children;
-        if ((node.kindString === 'Class' || node.kindString === 'Interface' || node.kindString === 'Object literal') &&
+        if ((node.kindString === 'Class' || node.kindString === 'Interface' ||
+          node.kindString === 'Object literal' || node.kindString === 'Module') &&
              children && children.length > 0) {
           children.forEach(function(child) {
             if (
@@ -97,7 +104,8 @@ TSParser.prototype.parse = function() {
              // This is needed in UI, good to keep the eligibility logic at one place
               child.shouldDocument = true;
               processMarkdown(child);
-               if (child.kindString !== 'Property' && child.kindString !== 'Variable') {
+               if (node.kindString === 'Module' ||
+                (child.kindString !== 'Property' && child.kindString !== 'Variable')) {
                 // Don't create section for property
                 createAnchor(child);
                 this.sections.push({'title': child.name, 'anchor': child.anchorId, 'depth': 4});
@@ -115,13 +123,9 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
   var exportedConstructs = [];
   function findConstructs(node, filePaths, parent) {
     // Global = 0, ExternalModule = 1, Module = 2
-    if (node.kind === 0 || node.kind === 1 || node.kind === 2) {
+    if (node.kind === 0 || node.kind === 1) {
       var children = node.children;
       if (children && children.length > 0) {
-        if (node.kind === 2) {
-          // Keep track of namespaces and object literals
-          parent = parent? parent + '.' + node.name : node.name;
-        }
         children.forEach(function(child) {
           findConstructs(child, filePaths, parent);
         });
@@ -131,10 +135,12 @@ TSParser.prototype.findExportedConstructs = function(node, filePaths) {
       node.kindString === 'Interface' ||
       node.kindString === 'Type alias' ||
       node.kindString === 'Object literal' ||
+      node.kindString === 'Module' ||
+      node.kindString === 'Variable' ||
       (node.kindString === 'Function' &&
         node.flags.isExported)) &&
         filePaths.find(function(filePath){
-          if(node.sources[0].fileName.split("/").pop() === filePath.split("/").pop()){
+          if(node.sources[0].fileName.split('/').pop() === filePath.split('/').pop()){
             return true;
           }
         })
@@ -152,6 +158,8 @@ function createAnchor(node) {
   //node.anchorId = node.kindString + node.name.replace('$', '') + node.id;
   if (node.kindString === 'Class' || node.kindString === 'Interface' ||
     node.kindString === 'Object literal' ||
+    node.kindString === 'Variable' ||
+    node.kindString === 'Module' ||
     node.kindString === 'Type alias') {
     node.anchorId = node.name;
   } else {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -73,6 +73,9 @@ code {
 .code-arg-types {
   font-weight: bold;
 }
+.code-arg-flags {
+  font-weight: normal;
+}
 .code-arg-desc {
   margin-top: 10px;
 }
@@ -93,10 +96,13 @@ code {
 }
 
 .params .hdr-name {
-  width: 20%;
+  width: 15%;
 }
 .params .hdr-type {
-  width: 20%;
+  width: 15%;
+}
+.params .hdr-flags {
+  width: 10%;
 }
 .params .hdr-desc {
   width: 60%;

--- a/templates/tsConstructs/method.ejs
+++ b/templates/tsConstructs/method.ejs
@@ -3,7 +3,7 @@ if (Array.isArray(signatures)) {
   // An overloaded function has multiple signatures
   signatures.forEach(function(signature) {
 %>
-  <%- include('methodSignature', {signature: signature}); %>
+  <%- include('methodSignature', {flags: flags, signature: signature}); %>
 <%
   });
 }

--- a/templates/tsConstructs/methodSignature.ejs
+++ b/templates/tsConstructs/methodSignature.ejs
@@ -17,6 +17,7 @@ var methodComment = signature.comment || null;
         <tr>
             <th class="hdr-name">Name</th>
             <th class="hdr-type">Type</th>
+            <th class="hdr-flags">Flags</th>
             <th class="hdr-desc">Description</th>
         </tr>
 <%
@@ -28,6 +29,9 @@ var methodComment = signature.comment || null;
                 </td>
                 <td class="code-arg-types">
                     <%- include('type', param); %>
+                </td>
+                <td class="code-arg-flags">
+                    <%- tsHelpers.getFlags(param.flags) %>
                 </td>
                 <td class="code-arg-desc">
                     <%- include('comments', param); %>

--- a/templates/tsConstructs/namespace-members.ejs
+++ b/templates/tsConstructs/namespace-members.ejs
@@ -1,0 +1,21 @@
+<%
+    var templates = {
+        'Class': 'class',
+        'Interface': 'interface',
+        'Function': 'function',
+        'Variable': 'variable',
+        'Object literal': 'objectLiteral',
+        'Module': 'namespace',
+        'Type alias': 'typeAlias'
+    };
+    if (locals.children && locals.children.length > 0) {
+        children.filter(function(c) {
+            return c.shouldDocument;
+        }).forEach(function(child) {
+            child.name = name + '.' + child.name;
+%>
+        <%- include(templates[child.kindString], child); %>
+<%
+        });
+    }
+%>

--- a/templates/tsConstructs/namespace.ejs
+++ b/templates/tsConstructs/namespace.ejs
@@ -1,0 +1,6 @@
+<section class="code-doc ">
+    <a name="<%-anchorId%>"></a>
+    <h3 class="code-ref">Namespace: <%-name%></h3>
+    <% include comments %>
+</section>
+<% include namespace-members %>

--- a/templates/tsConstructs/properties.ejs
+++ b/templates/tsConstructs/properties.ejs
@@ -4,9 +4,10 @@
         <tr>
             <th class="hdr-name">Name</th>
             <th class="hdr-type">Type</th>
+            <th class="hdr-flags">Flags</th>
             <th class="hdr-desc">Description</th>
         </tr>
-        <%  var properties = properties || null;
+        <%
             if (properties && properties.length > 0) {
                 properties.forEach(function(param) {
         %>
@@ -17,6 +18,9 @@
                 </td>
                 <td class="code-arg-types">
                     <%- include('type', param); %>
+                </td>
+                <td class="code-arg-flags">
+                    <%- tsHelpers.getFlags(param.flags) %>
                 </td>
                 <td class="code-arg-desc">
                     <%- include('comments', param); %>

--- a/templates/tsConstructs/variable.ejs
+++ b/templates/tsConstructs/variable.ejs
@@ -1,0 +1,8 @@
+<section class="code-doc ">
+  <a name="<%-anchorId%>"></a>
+  <%
+  var kind = tsHelpers.getVariableType({kindString: kindString, flags: flags});
+  %>
+  <h3 class="code-ref"><%-kind%>: <%-name%>: <% include type %></h3>
+  <% include comments %>
+</section>

--- a/templates/tsConstructs/variables.ejs
+++ b/templates/tsConstructs/variables.ejs
@@ -4,9 +4,10 @@
         <tr>
             <th class="hdr-name">Name</th>
             <th class="hdr-type">Type</th>
+            <th class="hdr-flags">Flags</th>
             <th class="hdr-desc">Description</th>
         </tr>
-        <%  var variables = variables || null;
+        <%
             if (variables && variables.length > 0) {
                 variables.forEach(function(param) {
         %>
@@ -17,6 +18,9 @@
                 </td>
                 <td class="code-arg-types">
                     <%- include('type', param); %>
+                </td>
+                <td class="code-arg-flags">
+                    <%- tsHelpers.getFlags(param.flags) %>
                 </td>
                 <td class="code-arg-desc">
                     <%- include('comments', param); %>

--- a/test/ts-parser.test.js
+++ b/test/ts-parser.test.js
@@ -20,8 +20,7 @@ describe('TypeScript Parser Test', function() {
     expect(parsedData.constructs).to.have.length(4);
     expect(parsedData.constructs.map(function(c) {
       return c.node.name;
-    })).to.eql(['param.Message', 'param.path',
-      'Greeter', 'PathParameterValues']);
+    })).to.eql(['param', 'Greeter', 'PathParameterValues', 'greeter']);
     expect(parsedData.errors).to.have.length(0);
     var greeterClass = parsedData.constructs.filter(function(c) {
       return c.node.name === 'Greeter';
@@ -67,8 +66,8 @@ describe('TypeScript Parser Test', function() {
       excludeNotExported: false,
     });
     var parsedData = tsParser.parse();
-    expect(parsedData.sections).to.have.length(3);
-    expect(parsedData.constructs).to.have.length(1);
+    expect(parsedData.sections).to.have.length(4);
+    expect(parsedData.constructs).to.have.length(2);
     expect(parsedData.errors).to.have.length(0);
   });
 
@@ -80,8 +79,8 @@ describe('TypeScript Parser Test', function() {
       excludeNotExported: false,
     });
     var parsedData = tsParser.parse();
-    expect(parsedData.sections).to.have.length(3);
-    expect(parsedData.constructs).to.have.length(1);
+    expect(parsedData.sections).to.have.length(4);
+    expect(parsedData.constructs).to.have.length(2);
     expect(parsedData.errors).to.have.length(0);
   });
 


### PR DESCRIPTION
For example:

```ts
export namespace a {
  export const X = 1;
  export const Y = 2;
}

export const B = 'b';
```

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/issues/1299

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
