### PR TITLE
fix: use qualified name as anchor id

### DIFF
--- a/src/ts-helper.ts
+++ b/src/ts-helper.ts
@@ -29,13 +29,13 @@ export interface Node extends DeclarationReflection {
   filename?: string;
   tsHelpers?: TSHelper;
   comment_copy?: Comment;
-  anchorId?: string | number;
+  anchorId?: string;
   shouldDocument?: boolean;
 }
 
 export interface Section {
   title: string;
-  anchor?: string | number;
+  anchor?: string;
   depth: number;
   annotation?: Annotation;
 }

--- a/test/ts-parser.test.js
+++ b/test/ts-parser.test.js
@@ -28,6 +28,16 @@ describe('TypeScript Parser Test', function() {
       return c.node.name === 'Greeter';
     })[0].node;
     expect(greeterClass.children).have.length(4);
+    expect(
+      greeterClass.children.map(function(c) {
+        return c.anchorId;
+      })
+    ).to.eql([
+      'Greeter.constructor',
+      'Greeter.greeting',
+      'Greeter.greeting2',
+      'Greeter.greet',
+    ]);
     // Two overloaded signatures
     expect(greeterClass.children[3].signatures).have.length(2);
   });


### PR DESCRIPTION
### Description

Anchor ids for generated typedocs used to be numbers and they might change as the new members are added to source code. This PR uses qualified name for the anchor id to make it more meaningful.

#### Related issues
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/issues/1413

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
