### PR TITLE
Enable stalebot and update CODEOWNERS

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - critical
+  - p1
+  - major
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been closed due to continued inactivity. Thank you for your understanding.
+  If you believe this to be in error, please contact one of the code owners,
+  listed in the `CODEOWNERS` file at the top-level of this repository.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # the last matching pattern has the most precendence.
 
 # Core team members from IBM
-* @mpatsute
+* @raymondfeng


### PR DESCRIPTION
### Description
- Enable stalebot for this repo using https://github.com/strongloop/loopback-connector-mongodb/blob/master/.github/stale.yml as the reference. 
- Change the `CODEOWNERS` to reflect the current status.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
