### PR TITLE
chore: add LTS schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ![Strong Docs](assets/logo.png)
 
+**This module is in Active LTS mode, new features are no longer accepted.**
+<br/>(See [Module Long Term Support Policy](#module-long-term-support-policy)
+below.)
+
 ## Overview
 
 Create a single page documentation site for your node.js module using a set of [documentation source files](#documentation-source-files) including **github flavored markdown** and **JSDoc annotated JavaScript**.
@@ -417,3 +421,17 @@ function promiseUnresolvable(arg, callback) {
 
 }
 ```
+
+## Module Long Term Support Policy
+
+This module adopts the [
+Module Long Term Support (LTS)](http://github.com/CloudNativeJS/ModuleLTS) policy,
+ with the following End Of Life (EOL) dates:
+
+| Version | Status          | Published | EOL      |
+| ------- | --------------- | --------- | -------- |
+| 4.x     | Active LTS      | Aug 2018  | Dec 2020 |
+| 3.x     | End-of-Life     | May 2018  | Aug 2019 |
+| 2.x     | End-of-Life     | May 2018  | Aug 2019 |
+
+Learn more about our LTS plan in [docs](https://loopback.io/doc/en/contrib/Long-term-support.html).


### PR DESCRIPTION
### Description
Add the LTS schedule for this module.  
Following the similar table as https://github.com/strongloop/loopback-component-explorer#module-long-term-support-policy. 

Also, this module is only used for LoopBack 3.x.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
